### PR TITLE
Fix null reference exception if SchemeName not set

### DIFF
--- a/src/Microsoft.AspNetCore.OData.Authorization/ODataModelPermissionsExtractor.cs
+++ b/src/Microsoft.AspNetCore.OData.Authorization/ODataModelPermissionsExtractor.cs
@@ -533,9 +533,9 @@ namespace Microsoft.AspNetCore.OData.Authorization
             var schemeProperty = permissionRecord.FindProperty("SchemeName")?.Value as IEdmStringConstantExpression;
             var scopesProperty = permissionRecord.FindProperty("Scopes")?.Value as IEdmCollectionExpression;
 
-            var scopes = scopesProperty.Elements.Select(s => GetScopeData(s as IEdmRecordExpression));
+            var scopes = scopesProperty?.Elements.Select(s => GetScopeData(s as IEdmRecordExpression)) ?? Enumerable.Empty<PermissionScopeData>();
 
-            return new PermissionData() { SchemeName = schemeProperty.Value, Scopes = scopes.ToList() };
+            return new PermissionData() { SchemeName = schemeProperty?.Value, Scopes = scopes.ToList() };
         }
 
         private static PermissionScopeData GetScopeData(IEdmRecordExpression scopeRecord)


### PR DESCRIPTION
This fixes a null reference exception that occurs when extracting the permissions from the model if the `SchemeName` has not been set.

Given that `SchemeName` is not currently used there is no requirement for it to be set, however this is working on the assumption that going forward a `null` `SchemeName` would result in the permissions being applied to all auth schemes